### PR TITLE
android-property-service: Migrate to Enhanced ACG

### DIFF
--- a/files/sysbus/android-property-service.api.json
+++ b/files/sysbus/android-property-service.api.json
@@ -1,7 +1,7 @@
 {
- "system": [
-	"com.android.properties/setProperty",
-	"com.android.properties/getProperty",
-	"com.android.properties/getAllProperties"
+    "android-property-service.operation": [
+        "com.android.properties/setProperty",
+        "com.android.properties/getProperty",
+        "com.android.properties/getAllProperties"
     ]
 }

--- a/files/sysbus/android-property-service.role.json.in
+++ b/files/sysbus/android-property-service.role.json.in
@@ -1,6 +1,7 @@
 {
     "exeName":"@WEBOS_INSTALL_SBINDIR@/android-property-service",
     "type": "privileged",
+    "trustLevel": "oem",
     "allowedNames": ["com.android.properties"],
     "permissions": [
         {


### PR DESCRIPTION
In order to be able to use latest components from upstream webOS OSE.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>
